### PR TITLE
fix potential for passwords in logfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+---
+name: make release
+
+# manual workflow to make a new release for the default branch
+on:
+  workflow_dispatch:
+    branches:
+      - FRAMEWORK_6_0
+env:
+  components: "/home/runner/.composer/web/components/bin/horde-components -c /home/runner/.composer/web/components/config/maintaina.conf.dist"
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-20.04']
+        php-versions: ['8.1']
+    steps:
+    - name: Setup git
+      run:  |
+          mkdir -p ~/.ssh/ && ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts
+          git config --global user.name "Github CI Runner"
+          git config --global user.email "ci-job@maintaina.com"
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: gettext
+        ini-values: post_max_size=512M, max_execution_time=360
+        tools: composer:v2
+    - name: Setup composer
+      run: |
+          composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+          composer global config repositories.0 composer https://horde-satis.maintaina.com
+          composer global config minimum-stability dev
+          composer config --no-plugins --global allow-plugins.horde/horde-installer-plugin true
+          composer global require horde/horde-installer-plugin "2.3.0"
+          composer global require horde/components "dev-FRAMEWORK_6_0"
+    - name: write changelog
+      run: |
+          entries_amount=0; max_entries=100
+          PATTERN="^\[.*\] .*"
+
+          for commit in $(git rev-list FRAMEWORK_6_0)
+          do
+            msg=$(git log --format=%B -n 1 $commit | head -n 1)
+            if [ $entries_amount -gt $max_entries ]; then break; fi
+            if [[ $msg == 'Released'* ]]; then break; fi
+            if [[ $msg == 'Development mode for'* ]]; then break; fi
+            if [[ $msg =~ $PATTERN ]]; then
+              $components changed "$msg"
+              let "entries_amount+=1"
+            fi
+          done
+    - name: make release and push
+      run: |
+          $components release for maintaina
+          git push
+          git push origin --tags

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ run-tests.log
 /test/*/*/*/*.log
 /test/*/*/*/*.out
 
+/vendor/
+/web/
+/var/
+
+.phpunit.cache/
+composer.lock

--- a/.horde.yml
+++ b/.horde.yml
@@ -49,10 +49,14 @@ dependencies:
       horde/xml_element: ^3
   optional:
     composer:
-      horde/activesync: ^3
       horde/http: ^3
+      horde/activesync: ^3
       horde/lock: ^3
       horde/syncml: ^3
     ext:
       soap: '*'
       xmlrpc: '*'
+  dev:
+    composer:
+      horde/activesync: ^3
+      horde/test: ^3

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
             "role": "lead"
         }
     ],
-    "time": "2022-10-08",
+    "time": "2022-10-19",
     "repositories": [
         {
             "type": "composer",
@@ -41,10 +41,13 @@
         "horde/util": "^3 || dev-FRAMEWORK_6_0",
         "horde/xml_element": "^3 || dev-FRAMEWORK_6_0"
     },
-    "require-dev": {},
-    "suggest": {
+    "require-dev": {
         "horde/activesync": "^3 || dev-FRAMEWORK_6_0",
+        "horde/test": "^3 || dev-FRAMEWORK_6_0"
+    },
+    "suggest": {
         "horde/http": "^3 || dev-FRAMEWORK_6_0",
+        "horde/activesync": "^3 || dev-FRAMEWORK_6_0",
         "horde/lock": "^3 || dev-FRAMEWORK_6_0",
         "horde/syncml": "^3 || dev-FRAMEWORK_6_0",
         "ext-soap": "*",

--- a/lib/Horde/Rpc/ActiveSync.php
+++ b/lib/Horde/Rpc/ActiveSync.php
@@ -221,13 +221,14 @@ class Horde_Rpc_ActiveSync extends Horde_Rpc
      */
     protected function _handleError($e)
     {
-        $trace = $e->getTraceAsString();
         $m = $e->getMessage();
         $buffer = ob_get_clean();
 
         $this->_logger->err('Error in communicating with ActiveSync server: ' . $m);
-        $this->_logger->err($trace);
+        $b = new Horde_Support_Backtrace($e);
+        $this->_logger->err((string)$b);
         $this->_logger->err('Buffer contents: ' . $buffer);
+
     }
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="test/bootstrap.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="false">
+    <testsuites>
+        <testsuite name="horde/rpc">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/test/ActiveSyncTest.php
+++ b/test/ActiveSyncTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Horde\Rpc\Test;
+
+use Exception;
+use Horde\Test\TestCase;
+use Horde_ActiveSync;
+use Horde_Controller_Request_Http;
+use Horde_Exception;
+use Horde_Rpc_ActiveSync;
+
+class ActiveSyncTest extends TestCase
+{
+    protected Horde_Rpc_ActiveSync $activeSyncRpc;
+
+    /**
+     * Tests if the errorHandler method of Horde_Rpc_ActiveSync will write passwords in the log.
+     * To test this, you need to have 'zend.exception_ignore_args = Off' in the php.ini
+     */
+    public function testNoPwInLogmessages()
+    {
+        $activeSync = $this->createMock(Horde_ActiveSync::class);
+        $activeSync->method('getGetVars')->willReturn([
+            'Cmd' => 'OPTIONS',
+            'DeviceId' => 'test',
+            'DeviceType' => 'test',
+        ]);
+        $activeSync->method('handleRequest')->willReturnCallback(function ($cmd, $device) {
+            throw new Horde_Exception('test');
+        });
+
+        $request = $this->createMock(Horde_Controller_Request_Http::class);
+        $request->method('getMethod')->willReturn('POST');
+        $request->method('getServerVars')->willReturn([
+            'QUERY_STRING' => 'test',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '',
+        ]);
+        $logger = new StrLogger();
+
+        $this->activeSyncRpc = new Horde_Rpc_ActiveSync($request, [
+            'server' => $activeSync,
+            'logger' => $logger,
+        ]);
+
+        $this->pretendAuth('user', 'password', $request);
+
+        foreach ($logger->logs as $log) {
+            $this->assertFalse(strpos($log['msg'], 'password'));
+        }
+    }
+
+    protected function pretendAuth($user, $pw, $request)
+    {
+        $this->activeSyncRpc->getResponse($request);
+    }
+}

--- a/test/StrLogger.php
+++ b/test/StrLogger.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Horde\Rpc\Test;
+
+class StrLogger
+{
+    public array $logs = [];
+
+    public function log($msg, $level)
+    {
+        $this->logs[] = [
+            'msg' => $msg,
+            'level' => $level,
+        ];
+    }
+
+    public function err($msg)
+    {
+        $this->log($msg, 'ERROR');
+    }
+
+    public function debug($msg)
+    {
+        $this->log($msg, 'DEBUG');
+    }
+
+    public function notice($msg)
+    {
+        $this->log($msg, 'NOTICE');
+    }
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+$candidates = [
+    dirname(__FILE__, 2) . '/vendor/autoload.php',
+    dirname(__FILE__, 4) . '/autoload.php',
+];
+// Cover root case and library case
+foreach ($candidates as $candidate) {
+    if (file_exists($candidate)) {
+        require_once $candidate;
+        break;
+    }
+}
+\Horde_Test_Bootstrap::bootstrap(dirname(__FILE__));


### PR DESCRIPTION
The `Horde_Rpc_ActiveSync::_handleError`  method uses `getTraceAsString` which can include passwords if `zend.exception_ignore_args = Off` is set in the php.ini